### PR TITLE
Adding Ruby Laser as a prereq for Refraction science

### DIFF
--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -434,7 +434,7 @@ end
           recipe = "planetaris-refraction-science-pack"
         },
       },
-      prerequisites = {"planetaris-diamond-polishing","planetaris-nanoscale-lens","planetaris-simulating-unit"},
+      prerequisites = {"planetaris-diamond-polishing","planetaris-nanoscale-lens","planetaris-simulating-unit","planetaris-ruby-laser"},
       unit =
       {
         count = 2000,


### PR DESCRIPTION
Ruby lasers are required to make refraction science packs, but are not a prerequisite tech.