### PR TITLE
1.3.7

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.3.7
+Date: 2026-04-13
+  Balancing:
+    - Big refraction ray collector storage 24 -> 32
+    - Big refraction ray collector amount of refraction light received when hit a  6 -> 8
+  Bugfixes:
+    - Fixed crash with aai loaders
+    - Fixed beryllium coating and big refraction ray collector recycling into wrong ingredients
+---------------------------------------------------------------------------------------------------
 Version: 1.3.6
 Date: 2026-04-13
   Compatibility:

--- a/compat/aai-loaders.lua
+++ b/compat/aai-loaders.lua
@@ -1,5 +1,5 @@
 if mods["aai-loaders"] and settings.startup["aai-loaders-mode"].value ~= "graphics-only" then
-
-data.raw["item"]["aai-hyper-loader"].default_import_location = "hyarion"
-
+    if mods["planetaris-arig"] then
+        data.raw["item"]["aai-hyper-loader"].default_import_location = "hyarion"
+    end
 end

--- a/control.lua
+++ b/control.lua
@@ -71,7 +71,7 @@ script.on_nth_tick(60, function()
 				if current_energy > last_energy + energy_threshold then
 					tank.insert_fluid({
 						name = "planetaris-refraction-light",
-						amount = 6,
+						amount = 8,
 						temperature = 0
 					})
 				end

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,5 +1,4 @@
 require("compat.aai-loaders")
-require("compat.arig")
 require("compat.arcanyx")
 require("compat.celestial-weather")
 require("compat.lamp-post")

--- a/data.lua
+++ b/data.lua
@@ -38,6 +38,7 @@ require("prototypes.tips-and-tricks")
 
 --------------------- Compat
 
+require("compat.arig")
 require("compat.stone-sifting")
 require("compat.resource-spawner-overhaul")
 require("compat.bzlead")

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "planetaris-hyarion",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "title": "○🌐Planetaris: Hyarion",
   "author": "Syen",
   "factorio_version": "2.0",

--- a/prototypes/entities/big-refraction-ray-collector.lua
+++ b/prototypes/entities/big-refraction-ray-collector.lua
@@ -244,7 +244,7 @@ data.extend({
     fluid_box = {
         -- pipe_covers = planetaris_fiber_optics_covers_pictures(),
         filter = "planetaris-refraction-light",
-        volume = 24,
+        volume = 32,
         pipe_connections = {
             { direction = defines.direction.west,  position = { -0.5, -0.5 }, connection_category = "light"},
             { direction = defines.direction.east,  position = { 0.5, 0.5 },   connection_category = "light"},


### PR DESCRIPTION
Date: 2026-04-13
  Balancing:
    - Big refraction ray collector storage 24 -> 32
    - Big refraction ray collector amount of refraction light received when hit a  6 -> 8
  Bugfixes:
    - Fixed crash with aai loaders
    - Fixed beryllium coating and big refraction ray collector recycling into wrong ingredients