### PR TITLE
Balancing and Bugfix

### DIFF
--- a/PlanetarisLib.lua
+++ b/PlanetarisLib.lua
@@ -306,6 +306,26 @@ function PlanetarisLib.set_recipe_category(recipe_name, category)
     recipe.crafting_categories = category
 end
 
+--- Adds an additional crafting category
+--- @param recipe_name string
+--- @param category string
+function PlanetarisLib.add_recipe_additional_category(recipe_name, category)
+    local recipe = data.raw.recipe[recipe_name]
+    if not recipe then
+        PlanetarisLib.error("Recipe:" .. recipe_name .. " does not exist.")
+        return
+    end
+    if recipe.additional_categories == nil then
+        recipe.additional_categories = {}
+    end
+    for _, existing_category in pairs(recipe.additional_categories) do
+        if existing_category == category then
+            return
+        end
+    end
+    table.insert(recipe.additional_categories, category)
+end
+
 --- Hide recipe in factoriopedia
 --- @param recipe_name string
 function PlanetarisLib.hide_recipe_factoriopedia(recipe_name)
@@ -513,6 +533,16 @@ function PlanetarisLib.add_tech_prerequisite_if_missing(tech_name, prereq_name)
     end
     
     table.insert(tech.prerequisites, prereq_name)
+end
+
+function PlanetarisLib.add_tech_effect(tech_name, effect)
+    local tech = data.raw.technology[tech_name]
+    if not tech then 
+        PlanetarisLib.error("Tech"..tech_name.."dont exist")
+    return
+    end
+  
+    table.insert(tech.effects, effect)
 end
 
 --- Removes a prerequisite from a technology

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.3.9
+Date: 2026-06-03
+  Balancing:
+    - Charged fluorite spoiling time 3 hours -> 6 hours
+    - Refraction generation light consumption 6/s -> 2/s
+  Bugfixes:
+    - Fixed pipe line extent of fiber optics cable being overriden to 320 by big refraction light collectors
+---------------------------------------------------------------------------------------------------
 Version: 1.3.8
 Date: 2026-05-08
   Compatibility:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "planetaris-hyarion",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "title": "○🌐Planetaris: Hyarion",
   "author": "Syen",
   "factorio_version": "2.0",

--- a/prototypes/entities/big-refraction-ray-collector.lua
+++ b/prototypes/entities/big-refraction-ray-collector.lua
@@ -251,6 +251,7 @@ data.extend({
             { direction = defines.direction.north, position = { -0.5, -0.5 }, connection_category = "light"},
             { direction = defines.direction.south, position = { 0.5, 0.5 },   connection_category = "light"},
         },
+      max_pipeline_extent = 1000,
     },
     two_direction_only = false,
     window_bounding_box = {{0, 0}, {0, 0}},

--- a/prototypes/entities/entities.lua
+++ b/prototypes/entities/entities.lua
@@ -1014,9 +1014,9 @@ data:extend({
     dying_explosion = "steam-engine-explosion",
     alert_icon_shift = util.by_pixel(0, -12),
     heating_energy = "500kW",
-    drawing_box_vertical_extension = 1,
+    drawing_box_vertical_extension = 1.1,
     effectivity = 1,
-    fluid_usage_per_tick = 0.1,
+    fluid_usage_per_tick = 0.033,
     maximum_temperature = 500,
     max_power_output = "15MW",
     burns_fluid = false,
@@ -1047,7 +1047,8 @@ data:extend({
         { flow_direction = "input-output", direction = defines.direction.west,  position = {-1.5, -1.5}, connection_category = "light" }
       },
       filter = "planetaris-pure-light",
-      minimum_temperature = 100.0
+      minimum_temperature = 100.0,
+      max_pipeline_extent = 1000,
     },
     energy_source =
     {

--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -344,7 +344,7 @@ data:extend({
       { size = 64, filename = "__planetaris-hyarion__/graphics/icons/charged-fluorite-4.png", scale = 0.5, mipmap_count = 4 },
     },
 
-    spoil_ticks = 180 * minute,
+    spoil_ticks = 6 * hour,
     spoil_result = "planetaris-fluorite",
 
     inventory_move_sound = item_sounds.sulfur_inventory_move,


### PR DESCRIPTION
Date: 2026-06-03
  Balancing:
    - Charged fluorite spoiling time 3 hours -> 6 hours
    - Refraction generation light consumption 6/s -> 2/s
  Bugfixes:
    - Fixed pipe line extent of fiber optics cable being overriden to 320 by big refraction light collectors