### PR TITLE
1.3.14

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.3.14
+Date: 2026-07-28
+  Balancing:
+    - Reduced by 50% the amount of refraction light needed to make pure light and charged fluorite
+    - Extended crafting time of the charged fluorite and adjusted it to be 15x more efficient
+  Bugfixes:
+    - Fixed error with assembling machine 4 pipe graphics not appearing
+---------------------------------------------------------------------------------------------------
 Version: 1.3.13
 Date: 2026-07-22
   Compatibility:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "planetaris-hyarion",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "title": "○🌐Planetaris: Hyarion",
   "author": "Syen",
   "factorio_version": "2.1",

--- a/prototypes/entities/entities.lua
+++ b/prototypes/entities/entities.lua
@@ -36,6 +36,7 @@ assembler_machine_4_pipe_pictures = function ()
       scale = 0.5,
     }),
   }
+  return assembler4pipepictures
 end
 
 planetaris_fiber_optics_covers_pictures = function()
@@ -1193,7 +1194,7 @@ data:extend({
     damaged_trigger_effect = hit_effects.wall(),
     minable = {mining_time = 0.4, result = "planetaris-beryllium-coating"},
     fast_replaceable_group = nil,
-    max_health = 650,
+    max_health = 1200,
     heating_energy = "500kW",
     repair_speed_modifier = 3,
     corpse = "planetaris-beryllium-coating-remnants",

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -660,12 +660,12 @@ data:extend(
       name = "planetaris-charged-fluorite",
       icons = {{icon="__planetaris-hyarion__/graphics/icons/charged-fluorite.png", draw_background=true}},
       categories = {"refraction"},
-      energy_required = 5,
+      energy_required = 30,
       auto_recycle = false,
       enabled = false,
       ingredients =
       {
-        {type = "fluid", name = "planetaris-refraction-light", amount = 48},
+        {type = "fluid", name = "planetaris-refraction-light", amount = 360},
         {type = "item", name = "planetaris-fluorite", amount = 1},
       },
       results = {{type="item", name="planetaris-charged-fluorite", amount=1}},
@@ -680,14 +680,14 @@ data:extend(
       },
       categories = {"refraction"},
       subgroup = "hyarion-advanced-processes",
-      energy_required = 2,
+      energy_required = 30,
       auto_recycle = false,
       enabled = false,
       ingredients =
       {
         {type = "item", name = "planetaris-charged-fluorite", amount = 1},
       },
-      results = {{type="fluid", name="planetaris-pure-light", amount=48, temperature = 1600},
+      results = {{type="fluid", name="planetaris-pure-light", amount=720, temperature = 1600},
                  {type="item", name="planetaris-unstable-shard", amount=1}
       },
       allow_productivity = false,
@@ -705,7 +705,7 @@ data:extend(
       enabled = false,
       ingredients =
       {
-        {type = "fluid", name = "planetaris-refraction-light", amount = 48},
+        {type = "fluid", name = "planetaris-refraction-light", amount = 24},
         {type = "item", name = "planetaris-fluorite", amount = 1},
       },
       results = {{type="fluid", name="planetaris-pure-light", amount=48, temperature = 1600},


### PR DESCRIPTION
Date: 2026-07-28
  Balancing:
    - Reduced by 50% the amount of refraction light needed to make pure light and charged fluorite
    - Extended crafting time of the charged fluorite and adjusted it to be 15x more efficient
  Bugfixes:
    - Fixed error with assembling machine 4 pipe graphics not appearing